### PR TITLE
bug/이동 관련 버그 수정

### DIFF
--- a/Client/Assets/Resources/Prefabs/MyPlayer.prefab
+++ b/Client/Assets/Resources/Prefabs/MyPlayer.prefab
@@ -505,9 +505,9 @@ GameObject:
   - component: {fileID: 8193515131591070729}
   - component: {fileID: 5088701006018280498}
   - component: {fileID: 3214364738292246230}
+  - component: {fileID: 8168298888470079768}
   - component: {fileID: 2422066480184832058}
   - component: {fileID: 8691189585645863161}
-  - component: {fileID: 8008784154314564832}
   m_Layer: 0
   m_Name: MyPlayer
   m_TagString: MyPlayer
@@ -611,6 +611,18 @@ MonoBehaviour:
   m_DefaultActionMap: Player
   m_SplitScreenIndex: -1
   m_Camera: {fileID: 0}
+--- !u!114 &8168298888470079768
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5684022663209458036}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d530563fc9d3ab542855fba3657532d1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &2422066480184832058
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -633,19 +645,6 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: ab15c68f6a8f70c45bbc1c5e4f6d3afe, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _speed: 15
---- !u!114 &8008784154314564832
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5684022663209458036}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7f587c40120e62848a245fc31b24df74, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   _speed: 15

--- a/Client/Assets/Scripts/Controllers/MyPlayer/MyPlayerController.cs
+++ b/Client/Assets/Scripts/Controllers/MyPlayer/MyPlayerController.cs
@@ -1,16 +1,18 @@
 using Google.Protobuf.Protocol;
-using System;
 using UnityEngine;
 
 public class MyPlayerController : MonoBehaviour
 {
     [SerializeField]
-    float _speed = 15.0f;
+    float _moveSpeed = 15.0f;
+
+    [SerializeField]
+    float _rotationSpeed = 15.0f;
 
     private PlayerInputController _controller;
 
     private Vector3 _movementDirection = Vector3.zero;
-    private Rigidbody _rigidbody;
+    //private Rigidbody _rigidbody;
     private bool wDown;
     private Animator _anim;
 
@@ -65,7 +67,7 @@ public class MyPlayerController : MonoBehaviour
     private void Awake()
     {
         _controller = GetComponent<PlayerInputController>();
-        _rigidbody = GetComponent<Rigidbody>();
+        //_rigidbody = GetComponent<Rigidbody>();
         _anim = GetComponentInChildren<Animator>();
     }
 
@@ -74,9 +76,19 @@ public class MyPlayerController : MonoBehaviour
         _controller.OnMoveEvent += Move;
     }
 
-
-    private void FixedUpdate()
+    private void Update()
     {
+        if (_movementDirection == Vector3.zero)
+        {
+            _anim.SetBool("isRun", false);
+            State = CreatureState.Idle;
+        }
+        else
+        {
+            State = CreatureState.Moving;
+        }
+
+
         switch (State)
         {
             case CreatureState.Idle:
@@ -85,32 +97,26 @@ public class MyPlayerController : MonoBehaviour
                 ApplyMovement(_movementDirection);
                 break;
         }
-
-        if (State == CreatureState.Moving)
-            State = CreatureState.Idle;
     }
-
 
     private void Move(Vector3 direction)
     {
-        State = CreatureState.Moving;
         _movementDirection = direction;
     }
 
     private void ApplyMovement(Vector3 direction)
     {
-        _anim.SetBool("isRun", direction != Vector3.zero);
-        _anim.SetBool("isWalk", wDown);
 
+        _anim.SetBool("isWalk", wDown);
+        _anim.SetBool("isRun", true);
         wDown = Input.GetButton("Walk");
         if (wDown)
-            direction = direction * _speed * 0.3f;
+            direction = direction * 5f;
         else
-            direction = direction * _speed;
+            direction = direction * _moveSpeed;
 
-        _rigidbody.velocity = direction;
-
-        transform.LookAt(transform.position + direction);
+        transform.position += direction * Time.deltaTime;
+        transform.rotation = Quaternion.Lerp(transform.rotation, Quaternion.LookRotation(direction), Time.deltaTime * _rotationSpeed);
 
         SendMovePacket();
     }


### PR DESCRIPTION
# 변경(수정) 및 버그 내용
- Rigidbody 사용 문제
  - Rigidbody를 사용해서 이동 처리를 하고 있었는데 패킷 전송 속도가 늦춰짐
  - 유니티 물리 엔진에 대한 이해도가 낮아서 적용을 하는데 상당한 시간을 잡아먹습니다.
- transform.position을 사용해서 처리


# 다른 문제 사항
- 벽이나 구조물을 통과하는 문제 다시 발생
  - Raycast를 사용해서 해결할려고 했지만, 움직일 때마다 Raycast를 보내는 것은 부하가 크다고 생각해서 배제
  - 맵 데이터를 추출해서 서버에서 이동 가능한 곳을 검증하는 방식을 적용 예정


# 추가 내용
- Move 패킷을 Bitflag를 사용해서 압축해볼려고 했지만 불가능한 방법이라는 것을 알게되었습니다.
  - Move 패킷은 좌표 값이나 움직임 관련 정보가 들어가는데 이런 정보를 bit로 압축할 수는 없습니다.
  - 설령 압축을 한다고 해도 서버에서 다시 압축을 푸는 연산이 필요해서 부하가 생깁니다.